### PR TITLE
🐛 Pass VITE env vars to release build

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -78,6 +78,9 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
           TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
+          VITE_SIGNALING_SERVER_URL: ${{ secrets.VITE_SIGNALING_SERVER_URL }}
+          VITE_AUTH_SERVER_URL: ${{ secrets.VITE_AUTH_SERVER_URL }}
+          VITE_CLOUDFLARE_APP_ID: ${{ secrets.VITE_CLOUDFLARE_APP_ID }}
         with:
           projectPath: apps/desktop
           args: --target ${{ matrix.target }}


### PR DESCRIPTION
## Summary

Pass `VITE_SIGNALING_SERVER_URL`, `VITE_AUTH_SERVER_URL` and `VITE_CLOUDFLARE_APP_ID` from GitHub secrets to the Tauri build step. Without these, the app falls back to `http://localhost` URLs causing "Load failed".

## Required

Add these GitHub secrets before merging:
```
VITE_SIGNALING_SERVER_URL=https://call.collectif-pixel.fr
VITE_AUTH_SERVER_URL=https://auth.call.collectif-pixel.fr
VITE_CLOUDFLARE_APP_ID=f5390d204ee44bad117777d39f113860
```